### PR TITLE
Raises our own exception type instead of RuntimeError

### DIFF
--- a/lib/handcuffs/configuration.rb
+++ b/lib/handcuffs/configuration.rb
@@ -1,8 +1,10 @@
+require "handcuffs/errors/configuration_block_missing_error"
+
 module Handcuffs
   mattr_accessor :config
 
   def self.configure
-    raise 'must pass a block to Handcuffs.configure' unless block_given?
+    raise ConfigurationBlockMissingError unless block_given?
     @@config = Configurator.new
     yield @@config
   end

--- a/lib/handcuffs/error.rb
+++ b/lib/handcuffs/error.rb
@@ -1,0 +1,3 @@
+module Handcuffs
+  Error = Module.new
+end

--- a/lib/handcuffs/errors/configuration_block_missing_error.rb
+++ b/lib/handcuffs/errors/configuration_block_missing_error.rb
@@ -1,0 +1,11 @@
+require "handcuffs/error"
+
+module Handcuffs
+  class ConfigurationBlockMissingError < ArgumentError
+    include Handcuffs::Error
+
+    def to_s
+      "block argument required"
+    end
+  end
+end

--- a/spec/handcuffs/configuration_spec.rb
+++ b/spec/handcuffs/configuration_spec.rb
@@ -1,0 +1,8 @@
+require "rails"
+require "handcuffs/configuration"
+
+RSpec.describe Handcuffs do
+  specify do
+    expect{ described_class.configure }.to raise_error(Handcuffs::ConfigurationBlockMissingError)
+  end
+end

--- a/spec/handcuffs/errors/configuration_block_missing_error_spec.rb
+++ b/spec/handcuffs/errors/configuration_block_missing_error_spec.rb
@@ -1,0 +1,27 @@
+require "handcuffs/errors/configuration_block_missing_error"
+
+RSpec.describe Handcuffs::ConfigurationBlockMissingError do
+  matcher :be_caught_with do |expected_identifier|
+    match do |actual_exception|
+      begin
+        raise actual_exception
+      rescue expected_identifier => e
+        true
+      rescue
+        false
+      end
+    end
+  end
+
+  it do
+    is_expected.to be_caught_with(Handcuffs::Error)
+  end
+
+  it do
+    is_expected.to be_caught_with(ArgumentError)
+  end
+
+  specify do
+    expect(subject.message).to eql("block argument required")
+  end
+end


### PR DESCRIPTION
The reason we are raising our own exception type is so that clients
using our code can catch exceptions from our library without too much
trouble. I chose to make subclass an `ArgumentError` because the missing
block seemed like an argument error to me.

I used the `Handcuffs::Error` module to allow us to tag any exceptions
coming out of the library with the library name. This means that client
code could rescue all of our exceptions with `rescue Handcuffs::Error`
as long as any of our entry point code rescues the exceptions and tags
them.

``` ruby
def top_level
  #do something that raises an exception
rescue => e
  e.extend(Handcuffs::Error)
  raise
end
```

This will re-raise any exception that is caught, but will also tag it as
a library raised exception.

Amos King @adkron amos@binarynoggin.com
