### PR TITLE
Add handcuffs module declaration to handcuffs.rb

### DIFF
--- a/lib/handcuffs.rb
+++ b/lib/handcuffs.rb
@@ -1,6 +1,8 @@
 require 'rails'
 require 'active_record'
 
+module Handcuffs; end
+
 Dir[File.join(File.dirname(__FILE__), 'handcuffs', '*.rb')].each {|file| require file }
 
 ActiveRecord::Migration.extend Handcuffs::Extensions


### PR DESCRIPTION
Add module declaration to handcuffs.rb so gem works with tools that aren't as permissive as bundler. Hopefully this will fix a problem we have using it with Capistrano
