### PR TITLE
Add check for undeclared phases

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ To configure, first create a handcuff initializer and define a configuration
 # config/initializers/handcuffs.rb
 
 Handcuffs.configure do |config|
-  config.phases = [:pre_deploy, :post_deploy]
+  config.phases = [:pre_restart, :post_restart]
 end
 ```
 
@@ -22,7 +22,7 @@ Then call `phase` from inside your migrations
 
 class AddOnSaleColumn < ActiveRecord::Migration
 
-  phase :pre_deploy
+  phase :pre_restart
 
   def up
     add_column :products, :on_sale, :boolean
@@ -40,7 +40,7 @@ end
 
 class AddOnSaleIndex < ActiveRecord::Migration
 
-  phase :post_deploy
+  phase :post_restart
 
   def up
     add_index :products, :on_sale, algorithm: :concurrently
@@ -55,11 +55,11 @@ end
 
 You can then run your migrations in phases using
 ```bash
-rake handcuffs:migrate[pre_deploy]
+rake handcuffs:migrate[pre_restart]
 ```
 or
 ```bash
-rake handcuffs:migrate[post_deploy]
+rake handcuffs:migrate[post_restart]
 ```
 
 You can run all migrations using
@@ -77,8 +77,8 @@ error, you can define a default phase for migrations that don't define one.
 # config/initializers/handcuffs.rb
 
 Handcuffs.configure do |config|
-  config.phases = [:pre_deploy, :post_deploy]
-  config.default_phase = :pre_deploy
+  config.phases = [:pre_restart, :post_restart]
+  config.default_phase = :pre_restart
 end
 ```
 

--- a/lib/handcuffs/errors.rb
+++ b/lib/handcuffs/errors.rb
@@ -31,6 +31,16 @@
     end
   end
 
+  class HandcuffsUnknownPhaseDeclaredError < HandcuffsError
+    def initialize(found_phases, allowed_phases)
+      msg = <<-MESSAGE
+        found declarations for #{found_phases.to_sentence}
+        but only #{allowed_phases.to_sentence} are allowed
+      MESSAGE
+      super msg
+    end
+  end
+
   class HandcuffsPhaseOutOfOrderError < HandcuffsError
     def initialize(not_run_phase, attempted_phase)
       msg = <<-MESSAGE

--- a/lib/handcuffs/errors.rb
+++ b/lib/handcuffs/errors.rb
@@ -31,7 +31,7 @@
     end
   end
 
-  class HandcuffsUnknownPhaseDeclaredError < HandcuffsError
+  class HandcuffsPhaseUndeclaredError < HandcuffsError
     def initialize(found_phases, allowed_phases)
       msg = <<-MESSAGE
         found declarations for #{found_phases.to_sentence}

--- a/lib/handcuffs/errors.rb
+++ b/lib/handcuffs/errors.rb
@@ -5,7 +5,7 @@
     def initialize(task)
       msg = <<-MESSAGE
         rake #{task} requires a phase argument.
-        For example: #{task}[pre_deploy]
+        For example: #{task}[pre_restart]
       MESSAGE
       super(msg)
     end

--- a/lib/handcuffs/phase_filter.rb
+++ b/lib/handcuffs/phase_filter.rb
@@ -50,9 +50,9 @@ class Handcuffs::PhaseFilter
 
   def check_order_down!(by_phase, defined_phases)
     #There's no way to do this without some super hackery. If we run rake
-    #handcuffs::rollback[:post_deploy] and the top of the list (in desc order)
-    #in a pre_deploy, we don't know if that was run before or after the
-    #last post_deploy because we can't count on the versions to give us the
+    #handcuffs::rollback[:post_restart] and the top of the list (in desc order)
+    #in a pre_restart, we don't know if that was run before or after the
+    #last post_restart because we can't count on the versions to give us the
     #execution order. Without storing the execution order in another table,
     #there's no way to implement this
   end

--- a/lib/handcuffs/phase_filter.rb
+++ b/lib/handcuffs/phase_filter.rb
@@ -81,7 +81,7 @@ class Handcuffs::PhaseFilter
       .map { |mh| mh[:migration].handcuffs_phase }
       .reject(&:nil?)
       .select { |phase| !phase.in?(Handcuffs.config.phases) }.to_a
-    if (unknown_phases)
+    if (unknown_phases.any?)
       raise HandcuffsPhaseUndeclaredError.new(unknown_phases, Handcuffs.config.phases)
     end
   end

--- a/lib/handcuffs/phase_filter.rb
+++ b/lib/handcuffs/phase_filter.rb
@@ -79,7 +79,7 @@ class Handcuffs::PhaseFilter
     unknown_phases = migration_hashes
       .lazy
       .map { |mh| mh[:migration].handcuffs_phase }
-      .compact
+      .reject(&:nil?)
       .select { |phase| !phase.in?(Handcuffs.config.phases) }
     if (unknown_phases)
       raise HandcuffsPhaseUndeclaredError.new(unknown_phases, Handcuffs.config.phases)

--- a/lib/handcuffs/phase_filter.rb
+++ b/lib/handcuffs/phase_filter.rb
@@ -80,7 +80,7 @@ class Handcuffs::PhaseFilter
       .lazy
       .map { |mh| mh[:migration].handcuffs_phase }
       .compact
-      .select { |phase| !phase.in?(Handcuffs.config.phases }
+      .select { |phase| !phase.in?(Handcuffs.config.phases) }
     if (unknown_phases)
       raise HandcuffsPhaseUndeclaredError.new(unknown_phases, Handcuffs.config.phases)
     end

--- a/lib/handcuffs/phase_filter.rb
+++ b/lib/handcuffs/phase_filter.rb
@@ -44,8 +44,8 @@ class Handcuffs::PhaseFilter
     defined_phases.take_while { |defined_phase| defined_phase != attempted_phase }
       .detect { |defined_phase| by_phase.key?(defined_phase) }
       .tap do |defined_phase|
-      raise HandcuffsPhaseOutOfOrderError.new(defined_phase, attempted_phase) if defined_phase
-    end
+        raise HandcuffsPhaseOutOfOrderError.new(defined_phase, attempted_phase) if defined_phase
+      end
   end
 
   def check_order_down!(by_phase, defined_phases)

--- a/lib/handcuffs/phase_filter.rb
+++ b/lib/handcuffs/phase_filter.rb
@@ -76,7 +76,7 @@ class Handcuffs::PhaseFilter
   end
 
   def check_for_undeclared_phases!(migration_hashes)
-    unknown_phases = migrations_hashes
+    unknown_phases = migration_hashes
       .lazy
       .map { |mh| mh[:migration].handcuffs_phase }
       .compact

--- a/lib/handcuffs/phase_filter.rb
+++ b/lib/handcuffs/phase_filter.rb
@@ -43,8 +43,8 @@ class Handcuffs::PhaseFilter
     defined_phases.take_while { |defined_phase| defined_phase != attempted_phase }
       .detect { |defined_phase| by_phase.key?(defined_phase) }
       .tap do |defined_phase|
-        raise HandcuffsPhaseOutOfOrderError.new(defined_phase, attempted_phase) if defined_phase
-      end
+      raise HandcuffsPhaseOutOfOrderError.new(defined_phase, attempted_phase) if defined_phase
+    end
   end
 
   def check_order_down!(by_phase, defined_phases)
@@ -71,6 +71,18 @@ class Handcuffs::PhaseFilter
         filenames = nil_migration_hashes.map { |mh| mh[:proxy].filename }
         raise HandcuffsPhaseUndefinedError.new(filenames)
       end
+    end
+  end
+
+  def check_for_unknown_phases!(migration_hashes)
+    unknown_phases = migrations_hashes
+      .reject { |mh| mh[:migration].handcuffs_phase.nil? }
+      .select do |mh| 
+        !h[:migration].handcuffs_phase.in?(Handcuffs.config.phases)
+      end
+    if unknown_phases
+      raise HandcuffsUnknownPhaseError.new(uknown_phases.map { |mh| mh[:migration].handcuffs_phase }), 
+        Handcuffs.config.phases)
     end
   end
 

--- a/lib/handcuffs/phase_filter.rb
+++ b/lib/handcuffs/phase_filter.rb
@@ -80,7 +80,7 @@ class Handcuffs::PhaseFilter
       .lazy
       .map { |mh| mh[:migration].handcuffs_phase }
       .reject(&:nil?)
-      .select { |phase| !phase.in?(Handcuffs.config.phases) }
+      .select { |phase| !phase.in?(Handcuffs.config.phases) }.to_a
     if (unknown_phases)
       raise HandcuffsPhaseUndeclaredError.new(unknown_phases, Handcuffs.config.phases)
     end

--- a/lib/handcuffs/version.rb
+++ b/lib/handcuffs/version.rb
@@ -1,3 +1,3 @@
 module Handcuffs
-  VERSION = "1.0.2"
+  VERSION = "1.1.0"
 end

--- a/spec/dummy/Gemfile.lock
+++ b/spec/dummy/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../
   specs:
-    handcuffs (0.1.11)
+    handcuffs (1.1.0)
       rails (>= 4.0, < 5.0)
 
 GEM
@@ -104,7 +104,7 @@ GEM
       activesupport (= 4.2.6)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
-    rake (11.1.2)
+    rake (11.2.2)
     rspec-core (3.3.2)
       rspec-support (~> 3.3.0)
     rspec-expectations (3.3.1)
@@ -148,4 +148,4 @@ DEPENDENCIES
   rspec-rails (~> 3.0)
 
 BUNDLED WITH
-   1.11.2
+   1.12.5

--- a/spec/dummy/db/migrate/20160329040426_add_table_foo.rb
+++ b/spec/dummy/db/migrate/20160329040426_add_table_foo.rb
@@ -1,6 +1,6 @@
 class AddTableFoo < ActiveRecord::Migration
 
-  phase :pre_deploy
+  phase :pre_restart
 
   def up
     create_table :foo do |t|

--- a/spec/dummy/db/migrate/20160329042840_add_column_foo_widget_count.rb
+++ b/spec/dummy/db/migrate/20160329042840_add_column_foo_widget_count.rb
@@ -1,6 +1,6 @@
 class AddColumnFooWidgetCount < ActiveRecord::Migration
 
-  phase :pre_deploy
+  phase :pre_restart
 
   def up
     add_column :foo, :widget_count, :integer

--- a/spec/dummy/db/migrate/20160329224617_add_index_foo_widget_count.rb
+++ b/spec/dummy/db/migrate/20160329224617_add_index_foo_widget_count.rb
@@ -2,7 +2,7 @@ class AddIndexFooWidgetCount < ActiveRecord::Migration
 
   disable_ddl_transaction!
 
-  phase :post_deploy
+  phase :post_restart
 
   def up
     add_index :foo,

--- a/spec/dummy/db/migrate/20160330002738_add_column_foo_whatzit_count.rb
+++ b/spec/dummy/db/migrate/20160330002738_add_column_foo_whatzit_count.rb
@@ -1,6 +1,6 @@
 class AddColumnFooWhatzitCount < ActiveRecord::Migration
 
-  phase :pre_deploy
+  phase :pre_restart
 
   def up
     add_column :foo, :whatzit_count, :integer

--- a/spec/dummy/db/migrate/20160330003159_add_foo_whatzit_default.rb
+++ b/spec/dummy/db/migrate/20160330003159_add_foo_whatzit_default.rb
@@ -1,6 +1,6 @@
 class AddFooWhatzitDefault < ActiveRecord::Migration
 
-  phase :post_deploy
+  phase :post_restart
 
   def up
     change_column_default :foo, :whatzit_count, 0

--- a/spec/dummy/spec/handcuffs_rake_spec.rb
+++ b/spec/dummy/spec/handcuffs_rake_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'handcuffs:migrate' do
       end
     end
 
-    it 'raises unknown phase error if given unkown phase' do
+    it 'raises unknown phase error if given unknown phase' do
       expect { subject.invoke(:foo) }.to raise_error(HandcuffsUnknownPhaseError)
     end
 

--- a/spec/dummy/spec/handcuffs_rake_spec.rb
+++ b/spec/dummy/spec/handcuffs_rake_spec.rb
@@ -3,11 +3,11 @@ require_relative 'spec_helper.rb'
 RSpec.describe 'handcuffs:migrate' do
   include_context 'rake'
 
-  let!(:add_table_foo_version) { '20160329040426' } #pre_deploy
-  let!(:add_column_foo_widget_count_version){ '20160329042840' } #pre_deploy
-  let!(:add_index_foo_widget_count_version) { '20160329224617' } #post_deploy
-  let!(:add_column_foo_whatzit_count_version){ '20160330002738' } #pre_deploy
-  let!(:add_foo_whatzit_default_version){ '20160330003159' } #post_deploy
+  let!(:add_table_foo_version) { '20160329040426' } #pre_restart
+  let!(:add_column_foo_widget_count_version){ '20160329042840' } #pre_restart
+  let!(:add_index_foo_widget_count_version) { '20160329224617' } #post_restart
+  let!(:add_column_foo_whatzit_count_version){ '20160330002738' } #pre_restart
+  let!(:add_foo_whatzit_default_version){ '20160330003159' } #post_restart
   let!(:add_table_bar_version){ '20160330005509' } #none
 
   it 'raises an error when not passed a phase argument' do
@@ -16,14 +16,14 @@ RSpec.describe 'handcuffs:migrate' do
 
   it 'raises not configured error if Handcuffs is not configured' do
     Handcuffs.config = nil
-    expect { subject.invoke(:pre_deploy) }.to raise_error(HandcuffsNotConfiguredError)
+    expect { subject.invoke(:pre_restart) }.to raise_error(HandcuffsNotConfiguredError)
   end
 
   context 'with basic config' do
     before(:all) do
       Handcuffs.configure do |config|
-        config.phases = [:pre_deploy, :post_deploy]
-        config.default_phase = :pre_deploy
+        config.phases = [:pre_restart, :post_restart]
+        config.default_phase = :pre_restart
       end
     end
 
@@ -31,9 +31,9 @@ RSpec.describe 'handcuffs:migrate' do
       expect { subject.invoke(:foo) }.to raise_error(HandcuffsUnknownPhaseError)
     end
 
-    context '[pre_deploy]' do
-      it 'runs pre_deploy migrations only' do
-        subject.invoke(:pre_deploy)
+    context '[pre_restart]' do
+      it 'runs pre_restart migrations only' do
+        subject.invoke(:pre_restart)
         expect(SchemaMigrations.pluck(:version)).to eq [
           add_table_foo_version,
           add_column_foo_widget_count_version,
@@ -43,13 +43,13 @@ RSpec.describe 'handcuffs:migrate' do
       end
     end
 
-    context '[post_deploy]' do
-      it 'raises phase out of order error if post_deploy migrations run' do
-        expect { subject.invoke(:post_deploy) }.to raise_error(HandcuffsPhaseOutOfOrderError)
+    context '[post_restart]' do
+      it 'raises phase out of order error if post_restart migrations run' do
+        expect { subject.invoke(:post_restart) }.to raise_error(HandcuffsPhaseOutOfOrderError)
       end
 
-      it 'runs post_deploy migrations after pre_deploy migrations' do
-        subject.invoke(:pre_deploy)
+      it 'runs post_restart migrations after pre_restart migrations' do
+        subject.invoke(:pre_restart)
         expect(SchemaMigrations.pluck(:version)).to eq [
           add_table_foo_version,
           add_column_foo_widget_count_version,
@@ -57,7 +57,7 @@ RSpec.describe 'handcuffs:migrate' do
           add_table_bar_version
         ]
         subject.reenable
-        subject.invoke(:post_deploy)
+        subject.invoke(:post_restart)
         expect(SchemaMigrations.pluck(:version)).to eq [
           add_table_foo_version,
           add_column_foo_widget_count_version,
@@ -88,12 +88,12 @@ RSpec.describe 'handcuffs:migrate' do
   context 'no default phase' do
     before(:all) do
       Handcuffs.configure do |config|
-        config.phases = [:pre_deploy, :post_deploy]
+        config.phases = [:pre_restart, :post_restart]
       end
     end
 
     it 'raises error on nil phase' do
-      expect { subject.invoke(:pre_deploy) }.to raise_error(HandcuffsPhaseUndefinedError)
+      expect { subject.invoke(:pre_restart) }.to raise_error(HandcuffsPhaseUndefinedError)
     end
   end
 end
@@ -101,11 +101,11 @@ end
 RSpec.describe 'handcuffs:rollback' do
   include_context 'rake'
 
-  let! (:add_table_foo_version) { '20160329040426' } #pre_deploy
-  let! (:add_column_foo_widget_count_version){ '20160329042840' } #pre_deploy
-  let!(:add_index_foo_widget_count_version) { '20160329224617' } #post_deploy
-  let!(:add_column_foo_whatzit_count_version){ '20160330002738' } #pre_deploy
-  let!(:add_foo_whatzit_default_version){ '20160330003159' } #post_deploy
+  let! (:add_table_foo_version) { '20160329040426' } #pre_restart
+  let! (:add_column_foo_widget_count_version){ '20160329042840' } #pre_restart
+  let!(:add_index_foo_widget_count_version) { '20160329224617' } #post_restart
+  let!(:add_column_foo_whatzit_count_version){ '20160330002738' } #pre_restart
+  let!(:add_foo_whatzit_default_version){ '20160330003159' } #post_restart
   let!(:add_table_bar_version){ '20160330005509' } #none
 
   it 'raises an error when not passed a phase argument' do
@@ -114,22 +114,22 @@ RSpec.describe 'handcuffs:rollback' do
 
   it 'raises not configured error if Handcuffs is not configured' do
     Handcuffs.config = nil
-    expect { subject.invoke(:pre_deploy) }.to raise_error(HandcuffsNotConfiguredError)
+    expect { subject.invoke(:pre_restart) }.to raise_error(HandcuffsNotConfiguredError)
   end
 
   context 'with basic config' do
     before(:all) do
       Handcuffs.configure do |config|
-        config.phases = [:pre_deploy, :post_deploy]
-        config.default_phase = :pre_deploy
+        config.phases = [:pre_restart, :post_restart]
+        config.default_phase = :pre_restart
       end
     end
 
-    context '[post_deploy]' do
+    context '[post_restart]' do
 
-      it 'reverses last post_deploy migration' do
+      it 'reverses last post_restart migration' do
         rake['handcuffs:migrate'].invoke(:all)
-        subject.invoke(:post_deploy)
+        subject.invoke(:post_restart)
         expect(SchemaMigrations.pluck(:version)).to eq [
           add_table_foo_version,
           add_column_foo_widget_count_version,
@@ -140,10 +140,10 @@ RSpec.describe 'handcuffs:rollback' do
       end
     end
 
-    context '[pre_deploy]' do
-      it 'reverses last pre_deploy migration' do
+    context '[pre_restart]' do
+      it 'reverses last pre_restart migration' do
         rake['handcuffs:migrate'].invoke(:all)
-        subject.invoke(:pre_deploy)
+        subject.invoke(:pre_restart)
         expect(SchemaMigrations.pluck(:version)).to eq [
           add_table_foo_version,
           add_column_foo_widget_count_version,

--- a/spec/dummy/spec/support/shared_contexts/rake.rb
+++ b/spec/dummy/spec/support/shared_contexts/rake.rb
@@ -1,4 +1,4 @@
-#https://robots.thoughtbot.com/test-rake-tasks-like-a-boss
+# https://robots.thoughtbot.com/test-rake-tasks-like-a-boss
 require "rake"
 
 shared_context "rake" do


### PR DESCRIPTION
Raise `HandcuffsUndeclaredPhaseError` if you add `phase :foo` to a migration that is not configured with `:foo` as a valid phase.

Change all specs and docs to say `pre_restart` and `post_restart` instead of `pre_deploy` and `post_deploy` to better match intended use case
