### PR TITLE
Fix missing key error in migrate[all]

### DIFF
--- a/lib/handcuffs/phase_filter.rb
+++ b/lib/handcuffs/phase_filter.rb
@@ -59,7 +59,7 @@ class Handcuffs::PhaseFilter
 
   def all_phases_by_configuration_order(by_phase, defined_phases)
     defined_phases.reduce([]) do |acc, phase|
-      acc | by_phase[phase]
+      acc | Array(by_phase[phase])
     end.map { |mh| mh[:proxy] }
   end
 

--- a/lib/handcuffs/version.rb
+++ b/lib/handcuffs/version.rb
@@ -1,3 +1,3 @@
 module Handcuffs
-  VERSION = "1.1.0"
+  VERSION = "1.1.1"
 end


### PR DESCRIPTION
Fix bug caused by missing hash key

`rake handcuffs:migrate[all]` was failing if phases were declared that had no pending migrations
