### PR TITLE
Remove empty .ruby-version and gitignore it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /tmp/
 handcuffs-*.gem
 /gemfiles/*.gemfile.lock
+.ruby-version


### PR DESCRIPTION
For some reason there's an empty .ruby-version in this project, which
wipes out any global ruby settings you might have and causes you to use
system. Since this gem should support multiple versions of Ruby, let's
remove and gitignore this file.