### PR TITLE
Support Rails 5.1

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -5,3 +5,7 @@ end
 appraise "rails-5" do
   gem "rails", "5.0.0.1"
 end
+
+appraise "rails-5.1" do
+  gem "rails", "5.1"
+end

--- a/gemfiles/rails_5.1.gemfile
+++ b/gemfiles/rails_5.1.gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "rails", "4.2.7.1"
+gem "rails", "5.1"
 
 gemspec path: "../"

--- a/gemfiles/rails_5.gemfile
+++ b/gemfiles/rails_5.gemfile
@@ -4,4 +4,4 @@ source "https://rubygems.org"
 
 gem "rails", "5.0.0.1"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -17,9 +17,6 @@ module Dummy
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
-
-    # Do not swallow errors in after_commit/after_rollback callbacks.
-    config.active_record.raise_in_transactional_callbacks = true
   end
 end
 

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -1,3 +1,10 @@
+ACTIVE_RECORD_MIGRATION_CLASS = if Rails::VERSION::STRING < "5.0"
+                                  ActiveRecord::Migration
+                                else
+                                  rails_version = Rails::VERSION::STRING.split(".")[0..1].join(".")
+                                  eval("ActiveRecord::Migration[#{rails_version}]")
+                                end
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/spec/dummy/db/migrate/20160329040426_add_table_foo.rb
+++ b/spec/dummy/db/migrate/20160329040426_add_table_foo.rb
@@ -1,4 +1,4 @@
-class AddTableFoo < ActiveRecord::Migration
+class AddTableFoo < ACTIVE_RECORD_MIGRATION_CLASS
 
   phase :pre_restart
 

--- a/spec/dummy/db/migrate/20160329042840_add_column_foo_widget_count.rb
+++ b/spec/dummy/db/migrate/20160329042840_add_column_foo_widget_count.rb
@@ -1,4 +1,4 @@
-class AddColumnFooWidgetCount < ActiveRecord::Migration
+class AddColumnFooWidgetCount < ACTIVE_RECORD_MIGRATION_CLASS
 
   phase :pre_restart
 

--- a/spec/dummy/db/migrate/20160329224617_add_index_foo_widget_count.rb
+++ b/spec/dummy/db/migrate/20160329224617_add_index_foo_widget_count.rb
@@ -1,4 +1,4 @@
-class AddIndexFooWidgetCount < ActiveRecord::Migration
+class AddIndexFooWidgetCount < ACTIVE_RECORD_MIGRATION_CLASS
 
   disable_ddl_transaction!
 

--- a/spec/dummy/db/migrate/20160330002738_add_column_foo_whatzit_count.rb
+++ b/spec/dummy/db/migrate/20160330002738_add_column_foo_whatzit_count.rb
@@ -1,4 +1,4 @@
-class AddColumnFooWhatzitCount < ActiveRecord::Migration
+class AddColumnFooWhatzitCount < ACTIVE_RECORD_MIGRATION_CLASS
 
   phase :pre_restart
 

--- a/spec/dummy/db/migrate/20160330003159_add_foo_whatzit_default.rb
+++ b/spec/dummy/db/migrate/20160330003159_add_foo_whatzit_default.rb
@@ -1,4 +1,4 @@
-class AddFooWhatzitDefault < ActiveRecord::Migration
+class AddFooWhatzitDefault < ACTIVE_RECORD_MIGRATION_CLASS
 
   phase :post_restart
 

--- a/spec/dummy/db/migrate/20160330005509_add_table_bar.rb
+++ b/spec/dummy/db/migrate/20160330005509_add_table_bar.rb
@@ -1,4 +1,4 @@
-class AddTableBar < ActiveRecord::Migration
+class AddTableBar < ACTIVE_RECORD_MIGRATION_CLASS
 
   #look ma, no phase!
 


### PR DESCRIPTION
* Removes raise_in_transactional_callbacks from the dummy spec, as it's
not needed and removed in Rails 5.1
* Conditionally sets the ACTIVE_RECORD_MIGRATION_CLASS constant for the
fixtures to inherit from, as `ActiveRecord::Migration` is not a valid
thing to inherit from in Rails 5.1
* Adds a Rails 5.1 appraisal config