### PR TITLE
uses sqlite for specs instead of requiring a dependency on postgres

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,10 +100,9 @@ Or install it yourself as:
 
 ##Running specs
 
-The specs for handcuffs are in the dummy application at `/spec/dummy/spec`. The
-spec suite requires PostgreSQL. To run it you will have to set the environment
-variables `POSTGRES_DB_USERNAME` and `POSTGRES_DB_PASSWORD`. You can then run
-the suite using `rake spec`
+The specs for handcuffs are in the dummy application at `/spec/dummy/spec`.
+Run `rake db:create` to create the test Sqlite database before you run the specs
+for the first time. You can then run the specs using `rake spec`.
 
 ## Contributing
 

--- a/spec/dummy/Gemfile
+++ b/spec/dummy/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gem 'rails', "~> 4.2"
 gem 'handcuffs', path: "../../"
-gem 'pg'
+gem 'sqlite3'
 
 group :test do
   gem 'rspec-rails', '~> 3.0'

--- a/spec/dummy/Gemfile.lock
+++ b/spec/dummy/Gemfile.lock
@@ -63,7 +63,6 @@ GEM
     minitest (5.10.1)
     nokogiri (1.7.1)
       mini_portile2 (~> 2.1.0)
-    pg (0.20.0)
     pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -126,6 +125,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    sqlite3 (1.3.13)
     thor (0.19.4)
     thread_safe (0.3.6)
     tzinfo (1.2.3)
@@ -136,12 +136,12 @@ PLATFORMS
 
 DEPENDENCIES
   handcuffs!
-  pg
   pry
   pry-byebug
   pry-rails
   rails (~> 4.2)
   rspec-rails (~> 3.0)
+  sqlite3
 
 BUNDLED WITH
    1.14.6


### PR DESCRIPTION
not sure if you'll take this one, but thought i'd submit a pr anyway.

this will make it easier for people to run the specs without a dependency on postgres and specific environment variables.