### PR TITLE
Fix sub-heading markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Or install it yourself as:
 
     $ gem install handcuffs
 
-##Running specs
+## Running specs
 
 The specs for handcuffs are in the dummy application at `/spec/dummy/spec`. The
 spec suite requires PostgreSQL. To run it you will have to set the environment


### PR DESCRIPTION
The title 'Running specs' needed a space for it to properly show up as a title via markdown.

The irony of fixing a typo in a readme - while using a branch whos name is misspelled due to a typo is not lost on me.