### PR TITLE
Update `handcuffs` to 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2.0.0
+
 ### Added
 
 - CHANGELOG.md
+- Code coverage for specs
 
 ### Changed
 
@@ -20,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Rails 6.1, 7.0, 7.1 (via Appraisal).
 - Updated Bundler to 2.4.22.
 - Added Appraisal for dummy app testing.
+- Moved repo to procore-oss
 
 ### Removed
 

--- a/lib/handcuffs/version.rb
+++ b/lib/handcuffs/version.rb
@@ -1,3 +1,3 @@
 module Handcuffs
-  VERSION = "1.4.1"
+  VERSION = "2.0.0"
 end


### PR DESCRIPTION
Update handcuffs gem to 2.0.0

Signed-off-by: Yevhenii Ponomarenko <yevhenii.ponomarenko-contractor@procore.com>

Checklist:

* [x] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://github.com/procore-oss/handcuffs/blob/main/CONTRIBUTING.md)
* [x] My build is green
