### PR TITLE
chore: simplify release GitHub Action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,35 +6,38 @@ on:
     branches: [main]
   workflow_dispatch: # allow manual deployment through GitHub Action UI
 jobs:
-  release:
+  version-check:
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    outputs:
+      changed: ${{ steps.check.outputs.any_changed }}
     steps:
       - uses: actions/checkout@v4
-      - name: Version file changed
-        id: version-file-changed
+      - name: Check if version has been updated
+        id: check
         uses: tj-actions/changed-files@v42
         with:
           files: lib/handcuffs/version.rb
+  release:
+    runs-on: ubuntu-latest
+    needs: version-check
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.version-check.outputs.changed == 'true' }}
+    steps:
+      - uses: actions/checkout@v4
       - name: Set up Ruby
-        if: ${{ github.event_name == 'workflow_dispatch' || steps.version-file-changed.outputs.any_changed == 'true' }}
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.2
           bundler-cache: true
       - name: Installing dependencies
-        if: ${{ github.event_name == 'workflow_dispatch' || steps.version-file-changed.outputs.any_changed == 'true' }}
         run: bundle check --path=vendor/bundle || bundle install --path=vendor/bundle
       - name: Build gem file
-        if: ${{ github.event_name == 'workflow_dispatch' || steps.version-file-changed.outputs.any_changed == 'true' }}
         run: bundle exec rake build
       - uses: fac/ruby-gem-setup-credentials-action@v2
-        if: ${{ github.event_name == 'workflow_dispatch' || steps.version-file-changed.outputs.any_changed == 'true' }}
         with:
           user: ""
           key: rubygems
           token: ${{secrets.RUBY_GEMS_API_KEY}}
       - uses: fac/ruby-gem-push-action@v2
-        if: ${{ github.event_name == 'workflow_dispatch' || steps.version-file-changed.outputs.any_changed == 'true' }}
         with:
           key: rubygems


### PR DESCRIPTION
Move version file change check to its own job
allows us to simplify conditional checks to one
in other steps since they will be under their own
job now

Checklist:

* [x] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://github.com/procore-oss/handcuffs/blob/main/CONTRIBUTING.md)
* [ ] My build is green

<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Note on Versioning:

Maintainers will bump the version and do a release when they are ready to release (possibly multiple merged PRs). Please do not bump the version in your PRs.
-->
