### PR TITLE
chore: change github actions from tags to SHAs

### DIFF
--- a/.github/workflows/auto-assign-author.yaml
+++ b/.github/workflows/auto-assign-author.yaml
@@ -1,13 +1,15 @@
 name: 'Auto Author Assign'
-
 on:
   pull_request_target:
     types: [opened, reopened]
-
+permissions:
+  contents: read
 jobs:
   assign-author:
+    permissions:
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: toshimaru/auto-author-assign@v2.1.0
+      - uses: toshimaru/auto-author-assign@5921acc6d5cdbf184d1c50dd6ee080f10fe1d8f6 # v2.1.0
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,15 +1,12 @@
 name: "Custom CodeQL"
-
 on:
   workflow_dispatch:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
-
+    branches: ["main"]
 permissions:
   contents: read
-
 jobs:
   analyze:
     name: Analyze
@@ -19,25 +16,20 @@ jobs:
       actions: read
       contents: read
       security-events: write
-
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'ruby' ]
-
+        language: ['ruby']
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
-      with:
-        languages: ${{ matrix.language }}
-
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
-
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
-      with:
-        category: "/language:${{matrix.language}}"
+      - name: Checkout repository
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@c99bbc0c74b76ffa9be1dea4e8bc8c73d945d43f # v3
+        with:
+          languages: ${{ matrix.language }}
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@c99bbc0c74b76ffa9be1dea4e8bc8c73d945d43f # v3
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@c99bbc0c74b76ffa9be1dea4e8bc8c73d945d43f # v3
+        with:
+          category: "/language:${{matrix.language}}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,10 +12,10 @@ jobs:
     outputs:
       changed: ${{ steps.check.outputs.any_changed }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
       - name: Check if version has been updated
         id: check
-        uses: tj-actions/changed-files@v44
+        uses: tj-actions/changed-files@d6babd6899969df1a11d14c368283ea4436bca78 # v44
         with:
           files: lib/handcuffs/version.rb
   release:
@@ -23,9 +23,9 @@ jobs:
     needs: version-check
     if: ${{ github.event_name == 'workflow_dispatch' || needs.version-check.outputs.changed == 'true' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@d5fb7a202fc07872cb44f00ba8e6197b70cb0c55 # v1
         with:
           ruby-version: 3.2
           bundler-cache: true
@@ -33,11 +33,11 @@ jobs:
         run: bundle check --path=vendor/bundle || bundle install --path=vendor/bundle
       - name: Build gem file
         run: bundle exec rake build
-      - uses: fac/ruby-gem-setup-credentials-action@v2
+      - uses: fac/ruby-gem-setup-credentials-action@5f62d5f2f56a11c7422a92f81fbb29af01e1c00f # v2
         with:
           user: ""
           key: rubygems
           token: ${{secrets.RUBY_GEMS_API_KEY}}
-      - uses: fac/ruby-gem-push-action@v2
+      - uses: fac/ruby-gem-push-action@81d77bf568ff6659d7fae0f0c5a036bb0aeacb1a # v2
         with:
           key: rubygems

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -2,37 +2,33 @@
 name: Mark stale issues and pull requests
 on:
   schedule:
-  - cron: "30 1 * * *"
-
+    - cron: "30 1 * * *"
 permissions:
   contents: read
-
 jobs:
   stale:
     permissions:
-      issues: write  # for actions/stale to close stale issues
-      pull-requests: write  # for actions/stale to close stale PRs
+      issues: write # for actions/stale to close stale issues
+      pull-requests: write # for actions/stale to close stale PRs
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v9
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        # Number of days of inactivity before an issue becomes stale
-        days-before-stale: 60
-        # Number of days of inactivity before a stale issue is closed
-        days-before-close: 7
-        # Issues with these labels will never be considered stale
-        exempt-issue-labels: "on-hold,pinned,security"
-        exempt-pr-labels: "on-hold,pinned,security"
-        # Comment to post when marking an issue as stale.
-        stale-issue-message: >
-          This issue has been automatically marked as stale because it has not had
-          recent activity. It will be closed if no further activity occurs. Thank you
-          for your contributions.
-        stale-pr-message: >
-          This pull request has been automatically marked as stale because it has not had
-          recent activity. It will be closed if no further activity occurs. Thank you
-          for your contributions.
-        # Label to use when marking an issue as stale
-        stale-issue-label: 'no-issue-activity'
-        stale-pr-label: 'no-pr-activity'
+      - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          # Number of days of inactivity before an issue becomes stale
+          days-before-stale: 60
+          # Number of days of inactivity before a stale issue is closed
+          days-before-close: 7
+          # Issues with these labels will never be considered stale
+          exempt-issue-labels: "on-hold,pinned,security"
+          exempt-pr-labels: "on-hold,pinned,security"
+          # Comment to post when marking an issue as stale.
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions.
+
+          stale-pr-message: >
+            This pull request has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions.
+
+          # Label to use when marking an issue as stale
+          stale-issue-label: 'no-issue-activity'
+          stale-pr-label: 'no-pr-activity'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,10 +24,7 @@ jobs:
           POSTGRES_DB: handcuffs_test
           POSTGRES_HOST_AUTH_METHOD: trust
         options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
+          --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
         ports:
           - 5432:5432
     env:
@@ -36,9 +33,9 @@ jobs:
       RAILS_ENV: test
       BUNDLER_VERSION: 2.4.22
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
       - name: Set up Ruby ${{ matrix.ruby }}
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@d5fb7a202fc07872cb44f00ba8e6197b70cb0c55 # v1
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler: ${{ env.BUNDLER_VERSION }}


### PR DESCRIPTION
- [x] change GitHub Actions to use SHAs instead of tags
  - Why? - To prevent supply chain attack. Tags can move. They are mutable. SHAs are not.
  - used [frizbee](https://github.com/stacklok/frizbee) - ran `frizbee ghactions -d .github/workflows` locally - also fixes formatting

Checklist:

* [x] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://github.com/procore-oss/handcuffs/blob/main/CONTRIBUTING.md)
* [x] My build is green

<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Note on Versioning:

Maintainers will bump the version and do a release when they are ready to release (possibly multiple merged PRs). Please do not bump the version in your PRs.
-->
