### PR TITLE
Add phase_order rake task and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ end
 
 ### Running Migrations In Phases
 
-After Handcuffs is configured and migrations are properly tagged, you can then run  migrations in phases using the `handcuffs:migrate` rake task with the specific phase to be run:
+After Handcuffs is configured and migrations are properly tagged, you can then run migrations in phases using the `handcuffs:migrate` rake task with the specific phase to be run:
 
 ```bash
 rake 'handcuffs:migrate[pre_restart]'
@@ -121,7 +121,7 @@ or
 rake 'handcuffs:migrate[post_restart]'
 ```
 
-*Note:* If you run phases out of order there are any pre-requisite phases (e.g. `phase :pre_restart`) with migrations that have not yet been run. In which case, trying to run a dependent phase (e.g. `phase: post_restart`) will raise a `HandcuffsPhaseOutOfOrderError`.
+*Note:* If you run phases out of order, or attempt to run a phase before outstanding migrations with a prerequisite phase have been run, a `HandcuffsPhaseOutOfOrderError` will be raised. 
 
 ### Running All Migrations
 

--- a/lib/handcuffs/extensions.rb
+++ b/lib/handcuffs/extensions.rb
@@ -1,12 +1,12 @@
-module Handcuffs
-  module Extensions
+# frozen_string_literal: true
 
+module Handcuffs
+  # Extended by ActiveRecord::Migrator in order to track the current phase
+  module Extensions
     attr_reader :handcuffs_phase
 
     def phase(phase)
       @handcuffs_phase = phase
     end
-
   end
 end
-

--- a/lib/handcuffs/pending_filter_ext.rb
+++ b/lib/handcuffs/pending_filter_ext.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Handcuffs
+  # PendingFilter is prepended to ActiveRecord::Migrator in the rake tasks
+  # in order to check the current phase before it is run
+  module PendingFilterExt
+    def runnable
+      attempted_phase = self.class.handcuffs_phase
+      if @direction == :up
+        Handcuffs::PhaseFilter.new(attempted_phase, @direction).filter(super)
+      else
+        phase_migrations = Handcuffs::PhaseFilter.new(attempted_phase, @direction).filter(migrations)
+        runnable = phase_migrations[start..finish]
+        runnable.pop if target
+        runnable.find_all { |m| ran?(m) }
+      end
+    end
+  end
+end

--- a/lib/handcuffs/phases.rb
+++ b/lib/handcuffs/phases.rb
@@ -1,17 +1,22 @@
+# frozen_string_literal: true
+
 require 'tsort'
 
 module Handcuffs
+  # Phases encapsulates the list of phases and any interdependencies
   class Phases
     def initialize(phases)
       @phases = case phases
-      when Hash
-        phases
-      else
-        # Assume each entry depends on all entries before it
-        phases.each_with_object({}) do |phase, acc|
-          acc[phase] = phases.take_while { |defined_phase| defined_phase != phase }
-        end
-      end
+                when Hash
+                  phases.each_with_object({}) do |phase, acc|
+                    acc[phase[0].to_sym] = Array(phase[1]).map(&:to_sym)
+                  end
+                else
+                  # Assume each entry depends on all entries before it
+                  phases.map(&:to_sym).each_with_object({}) do |phase, acc|
+                    acc[phase] = phases.take_while { |defined_phase| defined_phase != phase }
+                  end
+                end
     end
 
     def to_sentence

--- a/lib/tasks/handcuffs.rake
+++ b/lib/tasks/handcuffs.rake
@@ -1,56 +1,50 @@
+# frozen_string_literal: true
+
 namespace :handcuffs do
-  task :migrate, [:phase] => :environment do |t,args|
+  task :migrate, [:phase] => :environment do |_t, args|
     phase = setup(args, 'handcuffs:migrate')
     patch_migrator!(phase)
     run_task('db:migrate')
   end
 
-  task :rollback, [:phase] => :environment do |t,args|
+  task :rollback, [:phase] => :environment do |_t, args|
     phase = setup(args, 'handcuffs:rollback')
     patch_migrator!(phase)
     run_task('db:rollback')
   end
 
-  def setup(args, task)
-    phase = args.phase
-    raise RequiresPhaseArgumentError.new(task) unless phase.present?
-    raise HandcuffsNotConfiguredError.new unless Handcuffs.config
-    phase = phase.to_sym
-    unless Handcuffs.config.phases.include?(phase) || phase == :all
-      raise HandcuffsUnknownPhaseError.new(phase, Handcuffs.config.phases)
+  task phase_order: :environment do
+    raise HandcuffsNotConfiguredError unless Handcuffs.config
+
+    puts 'Configured Handcuffs phases, in order, are:'
+    phases = Handcuffs.config.phases || return
+
+    phases.in_order.each_with_index do |phase, idx|
+      puts (idx + 1).to_s.rjust(3) + ". #{phase}, requires: #{phases.prereqs(phase).join(', ').presence || '(nothing)'}"
     end
-    phase
+  end
+
+  def setup(args, task)
+    phase = args.phase.presence&.to_sym
+
+    raise RequiresPhaseArgumentError.new(task) unless phase.present?
+
+    raise HandcuffsNotConfiguredError unless Handcuffs.config
+
+    return phase if Handcuffs.config.phases.include?(phase) || phase == :all
+
+    raise HandcuffsUnknownPhaseError.new(phase, Handcuffs.config.phases)
   end
 
   def patch_migrator!(phase)
-    ActiveRecord::Migrator.prepend(PendingFilter)
-    ActiveRecord::Migrator.extend(PhaseAccessor)
+    ActiveRecord::Migrator.prepend(Handcuffs::PendingFilterExt)
     ActiveRecord::Migrator.handcuffs_phase = phase
   end
 
   def run_task(name)
     Rake::Task.clear # necessary to avoid tasks being loaded several times in dev mode
-    Rails.application.load_tasks 
+    Rails.application.load_tasks
     Rake::Task[name].reenable # in case you're going to invoke the same task second time.
     Rake::Task[name].invoke
   end
-
-  module PendingFilter
-    def runnable
-      attempted_phase = self.class.handcuffs_phase
-      if(@direction == :up)
-        Handcuffs::PhaseFilter.new(attempted_phase, @direction).filter(super)
-      else
-        phase_migrations = Handcuffs::PhaseFilter.new(attempted_phase, @direction).filter(migrations)
-        runnable = phase_migrations[start..finish]
-        runnable.pop if target
-        runnable.find_all { |m| ran?(m) }
-      end
-    end
-  end
-
-  module PhaseAccessor
-    attr_accessor :handcuffs_phase
-  end
-
 end

--- a/spec/dummy/config/environments/development.rb
+++ b/spec/dummy/config/environments/development.rb
@@ -25,16 +25,16 @@ Rails.application.configure do
   # Debug mode disables concatenation and preprocessing of assets.
   # This option may cause significant delays in view rendering with a large
   # number of complex assets.
-  config.assets.debug = true
+  # config.assets.debug = true
 
   # Asset digests allow you to set far-future HTTP expiration dates on all assets,
   # yet still be able to expire them through the digest params.
-  config.assets.digest = true
+  # config.assets.digest = true
 
   # Adds additional error checking when serving assets at runtime.
   # Checks for improperly declared sprockets dependencies.
   # Raises helpful error messages.
-  config.assets.raise_runtime_errors = true
+  # config.assets.raise_runtime_errors = true
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true

--- a/spec/dummy/config/initializers/handcufs.rb
+++ b/spec/dummy/config/initializers/handcufs.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Handcuffs.configure do |config|
+  config.phases = {
+    # Prevent running post_restart migrations if there are outstanding
+    # pre_restart migrations
+    post_restart: [:pre_restart],
+    # Require pre_restarts before data_migrations, but do not enforce ordering
+    # between data_migrations and post_restarts
+    data_migrations: [:pre_restart],
+    # pre_restarts have no prerequisite phases
+    pre_restart: []
+  }
+end

--- a/spec/dummy/spec/handcuffs_rake_spec.rb
+++ b/spec/dummy/spec/handcuffs_rake_spec.rb
@@ -1,181 +1,173 @@
-require_relative 'spec_helper.rb'
+# frozen_string_literal: true
 
-RSpec.describe 'handcuffs:migrate' do
+require_relative 'spec_helper'
+
+RSpec.describe 'handcuffs.rake' do
   include_context 'rake'
+  let!(:add_table_foo_version) { '20160329040426' } # pre_restart
+  let!(:add_column_foo_widget_count_version) { '20160329042840' } # pre_restart
+  let!(:add_index_foo_widget_count_version) { '20160329224617' } # post_restart
+  let!(:add_column_foo_whatzit_count_version) { '20160330002738' } # pre_restart
+  let!(:add_foo_whatzit_default_version) { '20160330003159' } # post_restart
+  let!(:add_table_bar_version) { '20160330005509' } # none
 
-  let!(:add_table_foo_version) { '20160329040426' } #pre_restart
-  let!(:add_column_foo_widget_count_version){ '20160329042840' } #pre_restart
-  let!(:add_index_foo_widget_count_version) { '20160329224617' } #post_restart
-  let!(:add_column_foo_whatzit_count_version){ '20160330002738' } #pre_restart
-  let!(:add_foo_whatzit_default_version){ '20160330003159' } #post_restart
-  let!(:add_table_bar_version){ '20160330005509' } #none
+  describe 'handcuffs:migrate' do
+    it 'raises an error when not passed a phase argument' do
+      expect { subject.invoke }.to raise_error(RequiresPhaseArgumentError)
+    end
 
-  it 'raises an error when not passed a phase argument' do
-    expect { subject.invoke }.to raise_error(RequiresPhaseArgumentError)
-  end
+    it 'raises not configured error if Handcuffs is not configured' do
+      Handcuffs.config = nil
+      expect { subject.invoke(:pre_restart) }.to raise_error(HandcuffsNotConfiguredError)
+    end
 
-  it 'raises not configured error if Handcuffs is not configured' do
-    Handcuffs.config = nil
-    expect { subject.invoke(:pre_restart) }.to raise_error(HandcuffsNotConfiguredError)
-  end
+    context 'with basic config' do
+      before(:all) do
+        Handcuffs.configure do |config|
+          config.phases = %i[pre_restart post_restart]
+          config.default_phase = :pre_restart
+        end
+      end
 
-  context 'with basic config' do
-    before(:all) do
-      Handcuffs.configure do |config|
-        config.phases = [:pre_restart, :post_restart]
-        config.default_phase = :pre_restart
+      it 'raises unknown phase error if given unknown phase' do
+        expect { subject.invoke(:foo) }.to raise_error(HandcuffsUnknownPhaseError)
+      end
+
+      context 'when running phase [pre_restart]' do
+        it 'runs pre_restart migrations only' do
+          subject.invoke(:pre_restart)
+          expect(SchemaMigrations.pluck(:version)).to eq [
+            add_table_foo_version,
+            add_column_foo_widget_count_version,
+            add_column_foo_whatzit_count_version,
+            add_table_bar_version
+          ]
+        end
+      end
+
+      context 'when running phase [post_restart]' do
+        it 'raises phase out of order error if post_restart migrations run' do
+          expect { subject.invoke(:post_restart) }.to raise_error(HandcuffsPhaseOutOfOrderError)
+        end
+
+        it 'runs post_restart migrations after pre_restart migrations' do
+          subject.invoke(:pre_restart)
+          expect(SchemaMigrations.pluck(:version)).to eq [
+            add_table_foo_version,
+            add_column_foo_widget_count_version,
+            add_column_foo_whatzit_count_version,
+            add_table_bar_version
+          ]
+          subject.reenable
+          subject.invoke(:post_restart)
+          expect(SchemaMigrations.pluck(:version)).to eq [
+            add_table_foo_version,
+            add_column_foo_widget_count_version,
+            add_column_foo_whatzit_count_version,
+            add_table_bar_version,
+            add_index_foo_widget_count_version,
+            add_foo_whatzit_default_version
+          ]
+        end
+      end
+
+      context 'when running phase [all]' do
+        it 'runs all migrations' do
+          subject.invoke(:all)
+          expect(SchemaMigrations.pluck(:version)).to eq [
+            add_table_foo_version,
+            add_column_foo_widget_count_version,
+            add_column_foo_whatzit_count_version,
+            add_table_bar_version,
+            add_index_foo_widget_count_version,
+            add_foo_whatzit_default_version
+          ]
+        end
       end
     end
 
-    it 'raises unknown phase error if given unknown phase' do
-      expect { subject.invoke(:foo) }.to raise_error(HandcuffsUnknownPhaseError)
-    end
+    context 'with no default phase' do
+      before(:all) do
+        Handcuffs.configure do |config|
+          config.phases = %i[pre_restart post_restart]
+        end
+      end
 
-    context '[pre_restart]' do
-      it 'runs pre_restart migrations only' do
-        subject.invoke(:pre_restart)
-        expect(SchemaMigrations.pluck(:version)).to eq [
-          add_table_foo_version,
-          add_column_foo_widget_count_version,
-          add_column_foo_whatzit_count_version,
-          add_table_bar_version
-        ]
+      it 'raises error on nil phase' do
+        expect { subject.invoke(:pre_restart) }.to raise_error(HandcuffsPhaseUndefinedError)
       end
     end
 
-    context '[post_restart]' do
-      it 'raises phase out of order error if post_restart migrations run' do
+    context 'explicitly dependency graph' do
+      before(:all) do
+        Handcuffs.configure do |config|
+          config.phases = {
+            post_restart: [:pre_restart],
+            pre_restart: []
+          }
+          config.default_phase = :pre_restart
+        end
+      end
+
+      it 'can run phases without dependencies' do
+        expect { subject.invoke(:pre_restart) }.not_to raise_error
+      end
+
+      it 'enforces dependencies' do
         expect { subject.invoke(:post_restart) }.to raise_error(HandcuffsPhaseOutOfOrderError)
       end
 
-      it 'runs post_restart migrations after pre_restart migrations' do
+      it 'can run once dependencies run' do
         subject.invoke(:pre_restart)
-        expect(SchemaMigrations.pluck(:version)).to eq [
-          add_table_foo_version,
-          add_column_foo_widget_count_version,
-          add_column_foo_whatzit_count_version,
-          add_table_bar_version
-        ]
-        subject.reenable
-        subject.invoke(:post_restart)
-        expect(SchemaMigrations.pluck(:version)).to eq [
-          add_table_foo_version,
-          add_column_foo_widget_count_version,
-          add_column_foo_whatzit_count_version,
-          add_table_bar_version,
-          add_index_foo_widget_count_version,
-          add_foo_whatzit_default_version
-        ]
+        expect { subject.invoke(:post_restart) }.not_to raise_error
       end
-    end
-
-    context '[all]' do
-      it 'runs all migrations' do
-        subject.invoke(:all)
-        expect(SchemaMigrations.pluck(:version)).to eq [
-          add_table_foo_version,
-          add_column_foo_widget_count_version,
-          add_column_foo_whatzit_count_version,
-          add_table_bar_version,
-          add_index_foo_widget_count_version,
-          add_foo_whatzit_default_version,
-        ]
-      end
-    end
-
-  end
-
-  context 'no default phase' do
-    before(:all) do
-      Handcuffs.configure do |config|
-        config.phases = [:pre_restart, :post_restart]
-      end
-    end
-
-    it 'raises error on nil phase' do
-      expect { subject.invoke(:pre_restart) }.to raise_error(HandcuffsPhaseUndefinedError)
     end
   end
 
-  context 'explicitly dependency graph' do
-    before(:all) do
-      Handcuffs.configure do |config|
-        config.phases = {
-          post_restart: [:pre_restart],
-          pre_restart: [],
-        }
-        config.default_phase = :pre_restart
+  describe 'handcuffs:rollback' do
+    it 'raises an error when not passed a phase argument' do
+      expect { subject.invoke }.to raise_error(RequiresPhaseArgumentError)
+    end
+
+    it 'raises not configured error if Handcuffs is not configured' do
+      Handcuffs.config = nil
+      expect { subject.invoke(:pre_restart) }.to raise_error(HandcuffsNotConfiguredError)
+    end
+
+    context 'with basic config' do
+      before(:all) do
+        Handcuffs.configure do |config|
+          config.phases = %i[pre_restart post_restart]
+          config.default_phase = :pre_restart
+        end
       end
-    end
 
-    it 'can run phases without dependencies' do
-      expect { subject.invoke(:pre_restart) }.not_to raise_error
-    end
-
-    it 'enforces dependencies' do
-      expect { subject.invoke(:post_restart) }.to raise_error(HandcuffsPhaseOutOfOrderError)
-    end
-
-    it 'can run once dependencies run' do
-      subject.invoke(:pre_restart)
-      expect { subject.invoke(:post_restart) }.not_to raise_error
-    end
-  end
-end
-
-RSpec.describe 'handcuffs:rollback' do
-  include_context 'rake'
-
-  let! (:add_table_foo_version) { '20160329040426' } #pre_restart
-  let! (:add_column_foo_widget_count_version){ '20160329042840' } #pre_restart
-  let!(:add_index_foo_widget_count_version) { '20160329224617' } #post_restart
-  let!(:add_column_foo_whatzit_count_version){ '20160330002738' } #pre_restart
-  let!(:add_foo_whatzit_default_version){ '20160330003159' } #post_restart
-  let!(:add_table_bar_version){ '20160330005509' } #none
-
-  it 'raises an error when not passed a phase argument' do
-    expect { subject.invoke }.to raise_error(RequiresPhaseArgumentError)
-  end
-
-  it 'raises not configured error if Handcuffs is not configured' do
-    Handcuffs.config = nil
-    expect { subject.invoke(:pre_restart) }.to raise_error(HandcuffsNotConfiguredError)
-  end
-
-  context 'with basic config' do
-    before(:all) do
-      Handcuffs.configure do |config|
-        config.phases = [:pre_restart, :post_restart]
-        config.default_phase = :pre_restart
+      context '[post_restart]' do
+        it 'reverses last post_restart migration' do
+          rake['handcuffs:migrate'].invoke(:all)
+          subject.invoke(:post_restart)
+          expect(SchemaMigrations.pluck(:version)).to eq [
+            add_table_foo_version,
+            add_column_foo_widget_count_version,
+            add_column_foo_whatzit_count_version,
+            add_table_bar_version,
+            add_index_foo_widget_count_version
+          ]
+        end
       end
-    end
 
-    context '[post_restart]' do
-
-      it 'reverses last post_restart migration' do
-        rake['handcuffs:migrate'].invoke(:all)
-        subject.invoke(:post_restart)
-        expect(SchemaMigrations.pluck(:version)).to eq [
-          add_table_foo_version,
-          add_column_foo_widget_count_version,
-          add_column_foo_whatzit_count_version,
-          add_table_bar_version,
-          add_index_foo_widget_count_version,
-        ]
-      end
-    end
-
-    context '[pre_restart]' do
-      it 'reverses last pre_restart migration' do
-        rake['handcuffs:migrate'].invoke(:all)
-        subject.invoke(:pre_restart)
-        expect(SchemaMigrations.pluck(:version)).to eq [
-          add_table_foo_version,
-          add_column_foo_widget_count_version,
-          add_column_foo_whatzit_count_version,
-          add_index_foo_widget_count_version,
-          add_foo_whatzit_default_version
-        ]
+      context '[pre_restart]' do
+        it 'reverses last pre_restart migration' do
+          rake['handcuffs:migrate'].invoke(:all)
+          subject.invoke(:pre_restart)
+          expect(SchemaMigrations.pluck(:version)).to eq [
+            add_table_foo_version,
+            add_column_foo_widget_count_version,
+            add_column_foo_whatzit_count_version,
+            add_index_foo_widget_count_version,
+            add_foo_whatzit_default_version
+          ]
+        end
       end
     end
   end


### PR DESCRIPTION
The most confusing part about the proposed dependency graph configuration was understanding what the default order would be. And the biggest risks seemed to be in accidentally creating a circular dependency or specifying a dependency incorrectly. This change addresses some of those issues as follows"
1. Updates the phases class to coerce phase names into symbols, and dependencies into arrays of symbols
2. Introduces a rake task that prints out the order of phases and their dependencies.

It also does a major overhaul to the README that reflects the additional information and insights I gained while working in the code and testing the dependency features that I wish would have been in the README to begin with. Also: Updates the example rake tasks to a more modern Rails format, and the Procore logo to use the procore-oss source.

Output of new rake task (when run from `/spec/dummy` test application):
```
$ bundle exec rake handcuffs:phase_order

Configured Handcuffs phases, in order, are:
  1. pre_restart, requires: (nothing)
  2. post_restart, requires: pre_restart
  3. data_migrations, requires: pre_restart
```
I get the same output when I "mangle" the configuration as follows
```ruby
  config.phases = {
    # Prevent running post_restart migrations if there are outstanding
    # pre_restart migrations
    post_restart: :pre_restart,
    # Require pre_restarts before data_migrations, but do not enforce ordering
    # between data_migrations and post_restarts
    data_migrations: 'pre_restart',
    # pre_restarts have no prerequisite phases
    'pre_restart' => []
  }
```

Checklist:

* [x] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://github.com/procore-oss/handcuffs/blob/main/CONTRIBUTING.md)
* [x] My build is green

<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Note on Versioning:

Maintainers will bump the version and do a release when they are ready to release (possibly multiple merged PRs). Please do not bump the version in your PRs.
-->
